### PR TITLE
Fixing test failures in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
   - nightly
   - pypy
   - pypy3

--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -48,9 +48,12 @@ class FlakesPlugin(object):
         if config.option.flakes and isPythonFile(path.strpath):
             flakesignore = self.ignore(path)
             if flakesignore is not None:
-                item = FlakesItem.from_parent(parent,
-                                              fspath=path,
-                                              flakesignore=flakesignore)
+                if hasattr(FlakesItem, 'from_parent'):
+                    item = FlakesItem.from_parent(parent,
+                                                  fspath=path,
+                                                  flakesignore=flakesignore)
+                else:
+                    item = FlakesItem(path, parent, flakesignore)
                 return item
 
     def pytest_sessionfinish(self, session):

--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -46,9 +46,15 @@ class FlakesPlugin(object):
     def pytest_collect_file(self, path, parent):
         config = parent.config
         if config.option.flakes and isPythonFile(path.strpath):
-            flakes_ignore = self.ignore(path)
-            if flakes_ignore is not None:
-                return FlakesItem(path, parent, flakes_ignore)
+            flakesignore = self.ignore(path)
+            if flakesignore is not None:
+                if hasattr(FlakesItem, "from_parent"):
+                    item = FlakesItem.from_parent(parent,
+                                                  fspath=path,
+                                                  flakesignore=flakesignore)
+                    return item
+                else:
+                    return FlakesItem(path, parent, flakesignore)
 
     def pytest_sessionfinish(self, session):
         session.config.cache.set(HISTKEY, self.mtimes)
@@ -60,13 +66,20 @@ class FlakesError(Exception):
 
 class FlakesItem(pytest.Item, pytest.File):
 
-    def __init__(self, path, parent, flakesignore):
-        super(FlakesItem, self).__init__(path, parent)
+    def __init__(self, fspath, parent, flakesignore):
+        super(FlakesItem, self).__init__(fspath, parent)
         if hasattr(self, 'add_marker'):
             self.add_marker("flakes")
         else:
             self.keywords["flakes"] = True
         self.flakesignore = flakesignore
+
+    @classmethod
+    def from_parent(cls, parent, fspath, **kwargs):
+        flakesignore = kwargs.pop('flakesignore')
+        _self = getattr(super(FlakesItem, cls), 'from_parent', cls)(parent, flakesignore=flakesignore, fspath=fspath)
+        _self.setup()
+        return _self
 
     def setup(self):
         flakesmtimes = self.config._flakes.mtimes

--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -48,13 +48,10 @@ class FlakesPlugin(object):
         if config.option.flakes and isPythonFile(path.strpath):
             flakesignore = self.ignore(path)
             if flakesignore is not None:
-                if hasattr(FlakesItem, "from_parent"):
-                    item = FlakesItem.from_parent(parent,
-                                                  fspath=path,
-                                                  flakesignore=flakesignore)
-                    return item
-                else:
-                    return FlakesItem(path, parent, flakesignore)
+                item = FlakesItem.from_parent(parent,
+                                              fspath=path,
+                                              flakesignore=flakesignore)
+                return item
 
     def pytest_sessionfinish(self, session):
         session.config.cache.set(HISTKEY, self.mtimes)
@@ -73,13 +70,6 @@ class FlakesItem(pytest.Item, pytest.File):
         else:
             self.keywords["flakes"] = True
         self.flakesignore = flakesignore
-
-    @classmethod
-    def from_parent(cls, parent, fspath, **kwargs):
-        flakesignore = kwargs.pop('flakesignore')
-        _self = getattr(super(FlakesItem, cls), 'from_parent', cls)(parent, flakesignore=flakesignore, fspath=fspath)
-        _self.setup()
-        return _self
 
     def setup(self):
         flakesmtimes = self.config._flakes.mtimes

--- a/test_flakes.py
+++ b/test_flakes.py
@@ -20,7 +20,7 @@ python_files=check_*.py
 for x in []
     pass
 """)
-    result = testdir.runpytest("--flakes", "--ignore", testdir)
+    result = testdir.runpytest("--flakes", "--ignore", testdir.tmpdir)
     assert "1: invalid syntax" in result.stdout.str()
     assert 'passed' not in result.stdout.str()
 

--- a/test_flakes.py
+++ b/test_flakes.py
@@ -55,3 +55,17 @@ def test_non_py_ext(testdir):
     result = testdir.runpytest('--flakes')
     assert "UnusedImport\n'sys' imported but unused" in result.stdout.str()
     assert 'passed' not in result.stdout.str()
+
+
+def test_flakesignore(testdir):
+    testdir.makeini("""
+[pytest]
+flakes-ignore = ImportStarUsed
+""")
+    testdir.makepyfile("""
+from os import *
+""")
+    result = testdir.runpytest("--flakes")
+    assert "ignoring ImportStarUsed" in result.stdout.str()
+    assert "1: ImportStarUsed" not in result.stdout.str()
+    assert 'passed' not in result.stdout.str()

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     coverage html -d htmlcov-{envname}
 
 [pytest]
-addopts = --flakes --pep8
+# addopts = --flakes --pep8
+addopts = --flakes
 pep8ignore = E501
 norecursedirs = bin lib include Scripts .*

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37,py38
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
This is a redo of #29, which broke when the repo moved. 

I can't figure out how to make the second test failure go away properly. I believe it is related to the deprecation warning (#26). However, I can't figure out what the right fix is. I tried basing the fix off https://github.com/The-Compiler/pytest-mccabe/pull/8 but I get errors each time (see the commit message). 

TODO: 
- [ ] Add tests for flakesignore
- [ ] Figure out which version of pytest we need to pin to