### PR TITLE
implement collect

### DIFF
--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -101,6 +101,12 @@ class FlakesItem(pytest.Item, pytest.File):
             ignores = ""
         return (self.fspath, -1, "pyflakes-check%s" % ignores)
 
+    def collect(self):
+        """ returns a list of children (items and collectors)
+            for this collection node.
+        """
+        return (self,)
+
 
 class Ignorer:
     def __init__(self, ignorelines, coderex=re.compile(r"[EW]\d\d\d")):


### PR DESCRIPTION
Implement `collect` (from FlakesItem <- pytest.File <- pytest.FSCollector <- pytest.Collector).
This is only called by pytest when an `__init__.py` file is given as argument, e.g.

```bash 
$ pytest --flakes my_package/__init__.py
```

fixes https://github.com/asmeurer/pytest-flakes/issues/37

also see
- pytest-black https://github.com/shopkeep/pytest-black/pull/47